### PR TITLE
fix: typo in Azure product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # terraform-azurerm-avm-res-operationalinsights-workspace
 
-This repo is to deploy an Log Anayltics Workspace.
+This repo is to deploy an Log Analytics Workspace.
 
 Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. The module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to <https://semver.org/>
 
@@ -42,7 +42,7 @@ The following input variables are required:
 
 ### <a name="input_location"></a> [location](#input\_location)
 
-Description: (Required) Specifies the suppored Azure location where the Log Anayltics Workspace should exist. Changing this forces a new resource to be created
+Description: (Required) Specifies the suppored Azure location where the Log Analytics Workspace should exist. Changing this forces a new resource to be created
 
 Type: `string`
 

--- a/_header.md
+++ b/_header.md
@@ -1,5 +1,5 @@
 # terraform-azurerm-avm-res-operationalinsights-workspace
 
-This repo is to deploy an Log Anayltics Workspace.
+This repo is to deploy an Log Analytics Workspace.
 
 Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. The module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to <https://semver.org/>

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ DESCRIPTION
 
 variable "location" {
   type        = string
-  description = "(Required) Specifies the suppored Azure location where the Log Anayltics Workspace should exist. Changing this forces a new resource to be created"
+  description = "(Required) Specifies the suppored Azure location where the Log Analytics Workspace should exist. Changing this forces a new resource to be created"
   nullable    = false
 }
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Typo in the Azure product name.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
