### PR TITLE
fix: correct resource name condition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "name" {
   nullable    = false
 
   validation {
-    condition     = can(regex("^[a-z0-9-]{4,63}$", var.name))
+    condition     = can(regex("^[A-Za-z0-9-]{4,63}$", var.name))
     error_message = "The name must be a valid Log Analytics Workspace name."
   }
 }


### PR DESCRIPTION
## Description

The condition for Log Analytics Workspace name is currently incorrect. The correct condition as per Microsoft documentation is: "4-63 chars, Alphanumerics and hyphens. Start and end with alphanumeric."

source: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftoperationalinsights

Fixes #70 
Closes #70 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ X ] Azure Verified Module updates:
  - [ X ] Bugfix containing backwards compatible bug fixes
    - [ X ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ X ] I'm sure there are no other open Pull Requests for the same update/change
- [ X ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ X ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
