### PR TITLE
Fix: naming condition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "name" {
   nullable    = false
 
   validation {
-    condition     = can(regex("^[a-z0-9-]{4,63}$", var.name))
+    condition     = can(regex("^[A-Za-z0-9-]{4,63}$", var.name))
     error_message = "The name must be a valid Log Analytics Workspace name."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "name" {
   nullable    = false
 
   validation {
-    condition     = can(regex("^[A-Za-z0-9-]{4,63}$", var.name))
+    condition     = can(regex("^[A-Za-z0-9][A-Za-z0-9-]{2,61}[A-Za-z0-9]$", var.name))
     error_message = "The name must be a valid Log Analytics Workspace name."
   }
 }


### PR DESCRIPTION
## Description

PR #71 fixed the regex to match Microsoft's documentation and this PR improves upon this regex to meet the undocumented conditions which are found in Azure portal when trying to create a workspace resource:

"- The workspace name must be between 4 and 63 characters.
- The workspace name can contain only letters, numbers and '-'. The '-' shouldn't be the first or the last symbol."

![image](https://github.com/user-attachments/assets/d6390b49-77a2-4a05-9c18-8126923912c9)


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ X ] Azure Verified Module updates:
  - [ X ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ X ] I'm sure there are no other open Pull Requests for the same update/change
- [ X ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ X ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
