### PR TITLE
Add support for azapi version 2.0.1

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
     # TODO: Ensure all required providers are listed here.
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 1.15"
+      version = ">= 1.15, < 3"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Description

Adds support for azapi version 2.0.1 which is needed when using oidc based authentication in github actions.
Details on why this change is important can be found it #100 

Fixes #100 
Closes #100

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
